### PR TITLE
Update GitHub Actions CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,14 +16,10 @@ jobs:
     name: Test examples with ${{ matrix.version }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: ${{ matrix.version }}
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --examples
+      - run: cargo test --examples

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,6 +20,5 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: ${{ matrix.version }}
       - run: cargo test --examples

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
       - name: Hack publish-crates to not fail on paths
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,12 +10,11 @@ jobs:
     name: Publish to crates.io
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: stable
-          override: true
       - name: Hack publish-crates to not fail on paths
         run: |
           sed 's/, path = ".*"//' -i Cargo.toml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,21 +12,13 @@ jobs:
     name: Check and test on ${{ matrix.os }} with ${{ matrix.version }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           profile: minimal
           toolchain: ${{ matrix.version }}
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-      - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+          components: clippy
+      - run: cargo check
+      - run: cargo clippy -- -D warnings
+      - run: cargo test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: ${{ matrix.version }}
           components: clippy
       - run: cargo check


### PR DESCRIPTION
Hi. Thanks for the library! I want to help to actualize the library, it will be a Pull Request series. It's worth starting with CI actualization.

- update [actions/checkout](https://github.com/actions/checkout) to v4
- replace [actions-rs/cargo](https://github.com/actions-rs/cargo) with using cargo directly
- replace [unmaintained](https://github.com/actions-rs/toolchain/issues/216) [actions-rs/toolchain](https://github.com/actions-rs/toolchain) by [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain)

> Node 16 has reached its end of life, prompting us to initiate its deprecation process for GitHub Actions. Our plan is to transition all actions to run on Node 20 by Spring 2024. https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/