### PR TITLE
chore(deps): bump deadpool-redis

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 keywords = ["redis", "macro", "derive", "json"]
 
 [dependencies]
-deadpool-redis = "0.19"
+deadpool-redis = "0.20"
 redis = { version = "0.29", optional = true }
 redis-macros-derive = { version = "0.5", optional = true, path = "./redis-macros-derive" }
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ license = "MIT"
 keywords = ["redis", "macro", "derive", "json"]
 
 [dependencies]
-deadpool-redis = "0.20"
 redis = { version = "0.29", optional = true }
 redis-macros-derive = { version = "0.5", optional = true, path = "./redis-macros-derive" }
 serde = { version = "1.0", features = ["derive"], optional = true }
@@ -23,6 +22,7 @@ json = ["dep:redis", "dep:serde", "dep:serde_json"]
 macros = ["dep:redis-macros-derive"]
 
 [dev-dependencies]
+deadpool-redis = "0.20"
 redis = { version = "0.29", features = ["tokio-comp", "json"] }
 serde_yaml = "0.9"
 tokio = { version = "1.41", features = ["full"] }


### PR DESCRIPTION
Right now the package pulls two versions of `redis`, one **0.29** from a direct dependency and **0.28** from `deadpool-redis`.

I think it's worth placing a separate Cargo.toml for deadpool examples.

UPD: Was deadpool-redis added here by mistake? https://github.com/daniel7grant/redis-macros/commit/4274f738f37f321d903be5f8ad03dd985945c2d1