### PR TITLE
added support for multiple generics

### DIFF
--- a/tests/derive_from_redis_value.rs
+++ b/tests/derive_from_redis_value.rs
@@ -79,3 +79,21 @@ pub fn it_should_fail_if_input_is_missing() {
         panic!("UTF-8 parsing should fail.");
     }
 }
+
+#[derive(Debug, PartialEq, Deserialize, FromRedisValue)]
+struct Pair<K, V> {
+    key: K,
+    value: V,
+}
+
+#[test]
+pub fn it_should_deserialize_struct_with_multiple_generics() {
+    let expected = Pair {
+        key: 42u32,
+        value: "answer".to_string(),
+    };
+    let json = "{\"key\":42,\"value\":\"answer\"}";
+    let val = Value::BulkString(json.as_bytes().into());
+    let result = Pair::<u32, String>::from_redis_value(&val);
+    assert_eq!(result, Ok(expected));
+}

--- a/tests/derive_from_redis_value_redis_yaml.rs
+++ b/tests/derive_from_redis_value_redis_yaml.rs
@@ -40,3 +40,24 @@ addresses:
     let result = User::from_redis_value(&val);
     assert_eq!(result, Ok(user));
 }
+
+// new test at the end of tests/derive_from_redis_value_redis_yaml.rs
+
+#[derive(Debug, PartialEq, Deserialize, FromRedisValue)]
+#[redis_serializer(serde_yaml)]
+struct Pair<K, V> {
+    key: K,
+    value: V,
+}
+
+#[test]
+pub fn it_should_deserialize_struct_with_multiple_generics_with_yaml() {
+    let expected = Pair {
+        key: 42u32,
+        value: "answer".to_string(),
+    };
+    let yaml = "key: 42\nvalue: answer\n";
+    let val = Value::BulkString(yaml.as_bytes().into());
+    let result = Pair::<u32, String>::from_redis_value(&val);
+    assert_eq!(result, Ok(expected));
+}

--- a/tests/derive_to_redis_args.rs
+++ b/tests/derive_to_redis_args.rs
@@ -29,3 +29,22 @@ pub fn it_should_implement_the_to_redis_args_trait() {
     let bytes = user.to_redis_args();
     assert_eq!(bytes[0], "{\"id\":1,\"name\":\"Ziggy\",\"addresses\":[{\"Street\":\"Downing\"},{\"Road\":\"Abbey\"}]}".as_bytes());
 }
+
+#[derive(Debug, Serialize, ToRedisArgs)]
+struct Pair<K, V> {
+    first: K,
+    second: V,
+}
+
+#[test]
+pub fn it_should_implement_to_redis_args_for_multiple_generics() {
+    let pair = Pair {
+        first: 100u8,
+        second: "data".to_string(),
+    };
+    let bytes = pair.to_redis_args();
+    assert_eq!(
+        bytes[0],
+        "{\"first\":100,\"second\":\"data\"}".as_bytes()
+    );
+}

--- a/tests/derive_to_redis_args_redis_yaml.rs
+++ b/tests/derive_to_redis_args_redis_yaml.rs
@@ -40,3 +40,23 @@ addresses:
             .as_bytes()
     );
 }
+
+#[derive(Debug, Serialize, ToRedisArgs)]
+#[redis_serializer(serde_yaml)]
+struct Pair<K, V> {
+    first: K,
+    second: V,
+}
+
+#[test]
+pub fn it_should_implement_to_redis_args_for_multiple_generics_with_yaml() {
+    let pair = Pair {
+        first: 100u8,
+        second: "data".to_string(),
+    };
+    let bytes = pair.to_redis_args();
+    assert_eq!(
+        std::str::from_utf8(&bytes[0]).unwrap(),
+        "first: 100\nsecond: data\n"
+    );
+}

--- a/tests/json_wrapper.rs
+++ b/tests/json_wrapper.rs
@@ -100,3 +100,36 @@ pub fn it_should_fail_if_input_is_missing() {
         panic!("Value Nil should fail.");
     }
 }
+
+#[derive(Debug, PartialEq, Deserialize)]
+struct Pair<K, V> {
+    key: K,
+    value: V,
+}
+
+#[test]
+pub fn it_should_deserialize_json_wrapper_with_multiple_generics() {
+    let expected = Pair {
+        key: 10u16,
+        value: "ok".to_string(),
+    };
+    let val = Value::BulkString(
+        "[{\"key\":10,\"value\":\"ok\"}]".as_bytes().into(),
+    );
+    let result = Json::<Pair<u16, String>>::from_redis_value(&val);
+    if let Ok(Json(parsed)) = result {
+        assert_eq!(parsed, expected);
+    } else {
+        panic!("Generic JSON deserialization should succeed.");
+    }
+}
+
+#[test]
+pub fn it_should_fail_json_wrapper_with_mismatched_types() {
+    // key is a string and value is a number, should fail deserializing Pair<u8, String>
+    let val = Value::BulkString(
+        "[{\"key\":\"bad\",\"value\":123}]".as_bytes().into(),
+    );
+    let result = Json::<Pair<u8, String>>::from_redis_value(&val);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Added support & tests for multiple generics. This allows for complex type support like this:

```rust
#[derive(Serialize, Deserialize, ToRedisArgs, FromRedisValue]
pub struct Core<N, E>
where
    N: Node,
    E: EdgeBase,
{
    nodes: BTreeMap<Uuid, N>,
    outgoing_edges: BTreeMap<Uuid, Vec<Uuid>>,
    incoming_edges: BTreeMap<Uuid, Vec<Uuid>>,
    edges: BTreeMap<Uuid, E>,
}
```

closes #55 