### PR TITLE
Upgrade redis-rs to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "redis-macros"
-version = "1.0.0"
+version = "1.0.0-rc.1"
 dependencies = [
  "deadpool-redis",
  "redis 1.0.0",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "redis-macros-derive"
-version = "1.0.0"
+version = "1.0.0-rc.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "redis-macros"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 dependencies = [
  "deadpool-redis",
  "redis 1.0.0",
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "redis-macros-derive"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92eee65955fc9d44e8efda17dd3794b7cf1e9dd96f39b805ae551111f4b77ce2"
+checksum = "47ba378d39b8053bffbfc2750220f5a24a06189b5129523d5db01618774e0239"
 dependencies = [
  "arcstr",
  "bytes",
@@ -529,14 +529,15 @@ dependencies = [
  "tokio",
  "tokio-util",
  "url",
+ "xxhash-rust",
 ]
 
 [[package]]
 name = "redis-macros"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "deadpool-redis",
- "redis 1.0.0-rc.1",
+ "redis 1.0.0",
  "redis-macros-derive",
  "serde",
  "serde_json",
@@ -546,11 +547,11 @@ dependencies = [
 
 [[package]]
 name = "redis-macros-derive"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "redis 1.0.0-rc.1",
+ "redis 1.0.0",
  "syn",
 ]
 
@@ -876,6 +877,12 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "arcstr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,7 +95,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0965b977f1244bc3783bb27cd79cfcff335a8341da18f79232d00504b18eb1a"
 dependencies = [
  "deadpool",
- "redis",
+ "redis 0.32.7",
 ]
 
 [[package]]
@@ -319,9 +325,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.176"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "litemap"
@@ -494,6 +500,28 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "ryu",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "redis"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92eee65955fc9d44e8efda17dd3794b7cf1e9dd96f39b805ae551111f4b77ce2"
+dependencies = [
+ "arcstr",
+ "bytes",
+ "cfg-if",
+ "combine",
+ "futures-util",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
  "serde",
  "serde_json",
  "sha1_smol",
@@ -505,10 +533,10 @@ dependencies = [
 
 [[package]]
 name = "redis-macros"
-version = "0.5.6"
+version = "1.0.0-rc.0"
 dependencies = [
  "deadpool-redis",
- "redis",
+ "redis 1.0.0-rc.1",
  "redis-macros-derive",
  "serde",
  "serde_json",
@@ -518,11 +546,11 @@ dependencies = [
 
 [[package]]
 name = "redis-macros-derive"
-version = "0.5.6"
+version = "1.0.0-rc.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "redis",
+ "redis 1.0.0-rc.1",
  "syn",
 ]
 
@@ -648,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "redis-macros"
 description = "Simple macros and wrappers to redis-rs to automatically serialize and deserialize structs with serde."
-version = "0.5.6"
+version = "1.0.0-rc.0"
 edition = "2021"
 authors = ["Daniel Grant"]
 readme = "README.md"
@@ -11,8 +11,8 @@ license = "MIT"
 keywords = ["redis", "macro", "derive", "json"]
 
 [dependencies]
-redis = { version = "0.32.0", optional = true }
-redis-macros-derive = { version = "0.5", optional = true, path = "./redis-macros-derive" }
+redis = { version = "1.0.0-rc", optional = true }
+redis-macros-derive = { version = "1.0.0-rc", optional = true, path = "./redis-macros-derive" }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 
@@ -23,6 +23,7 @@ macros = ["dep:redis-macros-derive"]
 
 [dev-dependencies]
 deadpool-redis = "0.22"
-redis = { version = "0.32.0", features = ["tokio-comp", "json"] }
+redis = { version = "1.0.0-rc", features = ["tokio-comp", "json"] }
 serde_yaml = "0.9"
 tokio = { version = "1.41", features = ["full"] }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["redis", "macro", "derive", "json"]
 
 [dependencies]
 redis = { version = "1.0", optional = true }
-redis-macros-derive = { version = "1.0", optional = true, path = "./redis-macros-derive" }
+redis-macros-derive = { version = "1.0.0-rc.1", optional = true, path = "./redis-macros-derive" }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "redis-macros"
 description = "Simple macros and wrappers to redis-rs to automatically serialize and deserialize structs with serde."
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 edition = "2021"
 authors = ["Daniel Grant"]
 readme = "README.md"
@@ -11,8 +11,8 @@ license = "MIT"
 keywords = ["redis", "macro", "derive", "json"]
 
 [dependencies]
-redis = { version = "1.0.0-rc", optional = true }
-redis-macros-derive = { version = "1.0.0-rc", optional = true, path = "./redis-macros-derive" }
+redis = { version = "1.0", optional = true }
+redis-macros-derive = { version = "1.0", optional = true, path = "./redis-macros-derive" }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 
@@ -23,7 +23,7 @@ macros = ["dep:redis-macros-derive"]
 
 [dev-dependencies]
 deadpool-redis = "0.22"
-redis = { version = "1.0.0-rc", features = ["tokio-comp", "json"] }
+redis = { version = "1.0", features = ["tokio-comp", "json"] }
 serde_yaml = "0.9"
 tokio = { version = "1.41", features = ["full"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "redis-macros"
 description = "Simple macros and wrappers to redis-rs to automatically serialize and deserialize structs with serde."
-version = "1.0.0-rc.1"
+version = "1.0.0"
 edition = "2021"
 authors = ["Daniel Grant"]
 readme = "README.md"
@@ -12,7 +12,7 @@ keywords = ["redis", "macro", "derive", "json"]
 
 [dependencies]
 redis = { version = "1.0", optional = true }
-redis-macros-derive = { version = "1.0.0-rc.1", optional = true, path = "./redis-macros-derive" }
+redis-macros-derive = { version = "1.0", optional = true, path = "./redis-macros-derive" }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,9 +2,16 @@
 
 ## [Unreleased]
 
+## [1.0.0-rc.0]
+
 ### Updated
 
-- Update dependencies
+- **Breaking change**: Update Redis version to 1.0.0-rc.0
+    - This library mostly can be used without any changes, but read the [redis-rs breaking changes](https://github.com/redis-rs/redis-rs/blob/redis-1.0.0-rc.0/version1.md)
+    - Implement `ToSingleRedisArg` for types deriving the `ToSingleRedis` macro (see [ToSingleRedisArg trait](https://github.com/redis-rs/redis-rs/blob/redis-1.0.0-rc.0/version1.md#tosingleredisarg-trait-breaking-change))
+    - Change `FromRedisValue` to accept owned types (see [More efficient deserialization](https://github.com/redis-rs/redis-rs/blob/redis-1.0.0-rc.0/version1.md#more-efficient-deserialization-breaking-change))
+    - Change `FromRedisValue` error from `RedisError` to `ParsingError` ([Better error messages](https://github.com/redis-rs/redis-rs/blob/redis-1.0.0-rc.0/version1.md#better-error-messages-potentially-breaking))
+- Update other dependencies
 
 ## [0.5.6] - 2025-07-20
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@
     - Change `FromRedisValue` to accept owned types (see [More efficient deserialization](https://github.com/redis-rs/redis-rs/blob/redis-1.0.0/version1.md#more-efficient-deserialization-breaking-change))
     - Change `FromRedisValue` error from `RedisError` to `ParsingError` ([Better error messages](https://github.com/redis-rs/redis-rs/blob/redis-1.0.0/version1.md#better-error-messages-potentially-breaking))
 - Update other dependencies
+- Fix the code comments to pass on nightly
 
 ## [0.5.6] - 2025-07-20
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,15 +2,15 @@
 
 ## [Unreleased]
 
-## [1.0.0-rc.0]
+## [1.0.0]
 
 ### Updated
 
-- **Breaking change**: Update Redis version to 1.0.0-rc.0
-    - This library mostly can be used without any changes, but read the [redis-rs breaking changes](https://github.com/redis-rs/redis-rs/blob/redis-1.0.0-rc.0/version1.md)
-    - Implement `ToSingleRedisArg` for types deriving the `ToSingleRedis` macro (see [ToSingleRedisArg trait](https://github.com/redis-rs/redis-rs/blob/redis-1.0.0-rc.0/version1.md#tosingleredisarg-trait-breaking-change))
-    - Change `FromRedisValue` to accept owned types (see [More efficient deserialization](https://github.com/redis-rs/redis-rs/blob/redis-1.0.0-rc.0/version1.md#more-efficient-deserialization-breaking-change))
-    - Change `FromRedisValue` error from `RedisError` to `ParsingError` ([Better error messages](https://github.com/redis-rs/redis-rs/blob/redis-1.0.0-rc.0/version1.md#better-error-messages-potentially-breaking))
+- **Breaking change**: Update Redis version to 1.0.0
+    - This library mostly can be used without any changes, but read the [redis-rs breaking changes](https://github.com/redis-rs/redis-rs/blob/redis-1.0.0/version1.md)
+    - Implement `ToSingleRedisArg` for types deriving the `ToSingleRedis` macro (see [ToSingleRedisArg trait](https://github.com/redis-rs/redis-rs/blob/redis-1.0.0/version1.md#tosingleredisarg-trait-breaking-change))
+    - Change `FromRedisValue` to accept owned types (see [More efficient deserialization](https://github.com/redis-rs/redis-rs/blob/redis-1.0.0/version1.md#more-efficient-deserialization-breaking-change))
+    - Change `FromRedisValue` error from `RedisError` to `ParsingError` ([Better error messages](https://github.com/redis-rs/redis-rs/blob/redis-1.0.0/version1.md#better-error-messages-potentially-breaking))
 - Update other dependencies
 
 ## [0.5.6] - 2025-07-20

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ To install it, simply add the package `redis-macros`. This package is a helper f
 
 ```toml
 [dependencies]
-redis-macros = "0.5"
-redis = { version = "0.29" }
+redis-macros = "1.0.0-rc"
+redis = { version = "1.0.0-rc" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 ```

--- a/examples/derive_deadpool.rs
+++ b/examples/derive_deadpool.rs
@@ -1,61 +1,63 @@
-use deadpool_redis::{
-    // Very important to import inner redis - otherwise macro expansion fails!
-    redis,
-    redis::{AsyncCommands, ErrorKind, RedisError, RedisResult},
-    Config,
-    Runtime,
-};
-use redis_macros::{FromRedisValue, ToRedisArgs};
-use serde::{Deserialize, Serialize};
+// TODO: COMMENTED OUT UNTIL DEADPOOL REDIS CATCHES UP WITH REDIS 1.0
+// use deadpool_redis::{
+//     // Very important to import inner redis - otherwise macro expansion fails!
+//     redis,
+//     redis::{AsyncCommands, ErrorKind, RedisError, RedisResult},
+//     Config,
+//     Runtime,
+// };
+// use redis_macros::{FromRedisValue, ToRedisArgs};
+// use serde::{Deserialize, Serialize};
+use redis::RedisResult;
 
-/// Define structs to hold the data
-/// Children structs don't have to implement FromRedisValue, ToRedisArgs, unless you want to use them as top level
-/// They have to implement serde traits though!
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-enum Address {
-    Street(String),
-    Road(String),
-}
+// /// Define structs to hold the data
+// /// Children structs don't have to implement FromRedisValue, ToRedisArgs, unless you want to use them as top level
+// /// They have to implement serde traits though!
+// #[derive(Debug, PartialEq, Serialize, Deserialize)]
+// enum Address {
+//     Street(String),
+//     Road(String),
+// }
 
-/// Don't forget to implement serde traits and redis traits!
-#[derive(Debug, PartialEq, Serialize, Deserialize, FromRedisValue, ToRedisArgs)]
-struct User {
-    id: u32,
-    name: String,
-    addresses: Vec<Address>,
-}
+// /// Don't forget to implement serde traits and redis traits!
+// #[derive(Debug, PartialEq, Serialize, Deserialize, FromRedisValue, ToRedisArgs)]
+// struct User {
+//     id: u32,
+//     name: String,
+//     addresses: Vec<Address>,
+// }
 
 /// Show a simple async usage of redis_macros traits
 /// Just derive the traits and forget them!
 #[tokio::main]
 async fn main() -> RedisResult<()> {
-    // Open new async connection to localhost
-    let cfg = Config::from_url("redis://localhost:6379");
+    // // Open new async connection to localhost
+    // let cfg = Config::from_url("redis://localhost:6379");
 
-    let pool = cfg.create_pool(Some(Runtime::Tokio1)).unwrap();
-    let mut con = pool.get().await.map_err(|_| {
-        RedisError::from((
-            ErrorKind::InvalidClientConfig,
-            "Cannot connect to localhost:6379. Try starting a redis-server process or container.",
-        ))
-    })?;
+    // let pool = cfg.create_pool(Some(Runtime::Tokio1)).unwrap();
+    // let mut con = pool.get().await.map_err(|_| {
+    //     RedisError::from((
+    //         ErrorKind::InvalidClientConfig,
+    //         "Cannot connect to localhost:6379. Try starting a redis-server process or container.",
+    //     ))
+    // })?;
 
-    // Define the data you want to store in Redis.
-    let user = User {
-        id: 1,
-        name: "Ziggy".to_string(),
-        addresses: vec![
-            Address::Street("Downing".to_string()),
-            Address::Road("Abbey".to_string()),
-        ],
-    };
+    // // Define the data you want to store in Redis.
+    // let user = User {
+    //     id: 1,
+    //     name: "Ziggy".to_string(),
+    //     addresses: vec![
+    //         Address::Street("Downing".to_string()),
+    //         Address::Road("Abbey".to_string()),
+    //     ],
+    // };
 
-    // Set and get back the user in Redis asynchronously, no problem
-    let _: () = con.set("user_deadpool", &user).await?;
-    let stored_user: User = con.get("user_deadpool").await?;
+    // // Set and get back the user in Redis asynchronously, no problem
+    // let _: () = con.set("user_deadpool", &user).await?;
+    // let stored_user: User = con.get("user_deadpool").await?;
 
-    // You will get back the same data
-    assert_eq!(user, stored_user);
+    // // You will get back the same data
+    // assert_eq!(user, stored_user);
 
     Ok(())
 }

--- a/redis-macros-derive/Cargo.lock
+++ b/redis-macros-derive/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "redis-macros"
-version = "1.0.0"
+version = "1.0.0-rc.1"
 dependencies = [
  "redis",
  "redis-macros-derive",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "redis-macros-derive"
-version = "1.0.0"
+version = "1.0.0-rc.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/redis-macros-derive/Cargo.lock
+++ b/redis-macros-derive/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "redis-macros"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 dependencies = [
  "redis",
  "redis-macros-derive",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "redis-macros-derive"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/redis-macros-derive/Cargo.lock
+++ b/redis-macros-derive/Cargo.lock
@@ -402,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92eee65955fc9d44e8efda17dd3794b7cf1e9dd96f39b805ae551111f4b77ce2"
+checksum = "47ba378d39b8053bffbfc2750220f5a24a06189b5129523d5db01618774e0239"
 dependencies = [
  "arcstr",
  "bytes",
@@ -423,11 +423,12 @@ dependencies = [
  "tokio",
  "tokio-util",
  "url",
+ "xxhash-rust",
 ]
 
 [[package]]
 name = "redis-macros"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "redis",
  "redis-macros-derive",
@@ -437,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "redis-macros-derive"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -732,6 +733,12 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"

--- a/redis-macros-derive/Cargo.lock
+++ b/redis-macros-derive/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "arcstr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,9 +31,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -35,14 +41,14 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "bytes"
@@ -52,9 +58,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "combine"
@@ -89,9 +95,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -130,15 +136,15 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "icu_collections"
@@ -228,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -249,9 +255,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -259,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -276,9 +282,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "litemap"
@@ -288,9 +294,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "miniz_oxide"
@@ -342,18 +348,18 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -369,37 +375,38 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "redis"
-version = "0.32.4"
+version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1f66bf4cac9733a23bcdf1e0e01effbaaad208567beba68be8f67e5f4af3ee1"
+checksum = "92eee65955fc9d44e8efda17dd3794b7cf1e9dd96f39b805ae551111f4b77ce2"
 dependencies = [
+ "arcstr",
  "bytes",
  "cfg-if",
  "combine",
@@ -420,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "redis-macros"
-version = "0.5.6"
+version = "1.0.0-rc.0"
 dependencies = [
  "redis",
  "redis-macros-derive",
@@ -430,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "redis-macros-derive"
-version = "0.5.6"
+version = "1.0.0-rc.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -456,18 +463,28 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -476,14 +493,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -507,9 +525,9 @@ checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -529,15 +547,15 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -572,7 +590,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
- "bytes",
  "io-uring",
  "libc",
  "mio",
@@ -584,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -597,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -609,13 +626,14 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -629,6 +647,12 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -767,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",

--- a/redis-macros-derive/Cargo.toml
+++ b/redis-macros-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "redis-macros-derive"
 description = "Derive macros for the redis-macros package"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 edition = "2021"
 authors = ["Daniel Grant"]
 readme = "README.md"

--- a/redis-macros-derive/Cargo.toml
+++ b/redis-macros-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "redis-macros-derive"
 description = "Derive macros for the redis-macros package"
-version = "0.5.6"
+version = "1.0.0-rc.0"
 edition = "2021"
 authors = ["Daniel Grant"]
 readme = "README.md"
@@ -16,11 +16,11 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-redis = "0.32.0"
+redis = "1.0.0-rc"
 syn = { version = "2.0" }
 
 [dev-dependencies]
-redis = { version = "0.32.0", features = ["tokio-comp", "json"] }
+redis = { version = "1.0.0-rc", features = ["tokio-comp", "json"] }
 redis-macros = { path = ".." }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }

--- a/redis-macros-derive/Cargo.toml
+++ b/redis-macros-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "redis-macros-derive"
 description = "Derive macros for the redis-macros package"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 edition = "2021"
 authors = ["Daniel Grant"]
 readme = "README.md"
@@ -16,11 +16,11 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-redis = "1.0.0-rc"
+redis = "1.0"
 syn = { version = "2.0" }
 
 [dev-dependencies]
-redis = { version = "1.0.0-rc", features = ["tokio-comp", "json"] }
+redis = { version = "1.0", features = ["tokio-comp", "json"] }
 redis-macros = { path = ".." }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }

--- a/src/json.rs
+++ b/src/json.rs
@@ -15,7 +15,7 @@ use serde::de::DeserializeOwned;
 /// # fn main () -> redis::RedisResult<()> {
 /// # let client = redis::Client::open("redis://localhost:6379/")?;
 /// # let mut con = client.get_connection()?;
-/// # con.json_set("user", "$", &r#"{ "id": 1 }"#)?;
+/// # let _: () = con.json_set("user", "$", &r#"{ "id": 1 }"#)?;
 /// // You have to manually deserialize this and pull from the Vec
 /// let user_id: String = con.json_get("user", "$.id")?;  // => "[1]"
 /// # Ok(())
@@ -35,7 +35,7 @@ use serde::de::DeserializeOwned;
 /// # fn main () -> redis::RedisResult<()> {
 /// # let client = redis::Client::open("redis://localhost:6379/")?;
 /// # let mut con = client.get_connection()?;
-/// # con.json_set("user", "$", &r#"{ "id": 1 }"#)?;
+/// # let _: () = con.json_set("user", "$", &r#"{ "id": 1 }"#)?;
 /// let Json(user_id): Json<u32> = con.json_get("user", "$.id")?;  // => 1
 /// let Json(user): Json<User> = con.json_get("user", "$")?;  // => User { id: 1 }
 /// # Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //!     };
 //!
 //!     // Just use it as you would a primitive
-//!     con.set("user", user)?;
+//!     let _: () = con.set("user", user)?;
 //!     // user and stored_user will be the same
 //!     let stored_user: User = con.get("user")?;
 //!     # Ok(())
@@ -68,7 +68,7 @@
 //! # let mut con = client.get_connection()?;
 //! # let user = User { id: 1, name: "Ziggy".to_string(), addresses: vec![ Address::Street("Downing".to_string()), Address::Road("Abbey".to_string()) ] };
 //! // Simple usage is equivalent to set-get
-//! con.json_set("user", "$", &user)?;
+//! let _: () = con.json_set("user", "$", &user)?;
 //! let stored_user: User = con.json_get("user", "$")?;
 //!
 //! // But you can get deep values - don't forget to derive traits for these too!
@@ -92,7 +92,7 @@
 //! # let client = redis::Client::open("redis://localhost:6379/")?;
 //! # let mut con = client.get_connection()?;
 //! # let user = User { id: 1, name: "Ziggy".to_string(), addresses: vec![ Address::Street("Downing".to_string()), Address::Road("Abbey".to_string()) ] };
-//! # con.json_set("user", "$", &user)?;
+//! # let _: () = con.json_set("user", "$", &user)?;
 //! // This WON'T work
 //! let stored_addresses: Vec<Address> = con.json_get("user", "$.addresses")?;
 //! # Ok(())
@@ -118,7 +118,7 @@
 //! # let client = redis::Client::open("redis://localhost:6379/")?;
 //! # let mut con = client.get_connection()?;
 //! # let user = User { id: 1, name: "Ziggy".to_string(), addresses: vec![ Address::Street("Downing".to_string()), Address::Road("Abbey".to_string()) ] };
-//! # con.json_set("user", "$", &user)?;
+//! # let _: () = con.json_set("user", "$", &user)?;
 
 //! // Return type can be wrapped into Json
 //! let Json(stored_name): Json<String> = con.json_get("user", "$.name")?;
@@ -145,10 +145,10 @@
 //! # let client = redis::Client::open("redis://localhost:6379/")?;
 //! # let mut con = client.get_connection()?;
 //! # let user = User {};
-//! # con.json_set("user", "$", &user)?;
+//! # let _: () = con.json_set("user", "$", &user)?;
 //!
 //! // This works with simple redis-rs
-//! con.json_set("user", "$", &user)?;
+//! let _: () = con.json_set("user", "$", &user)?;
 //! // ...and you can get back with Json wrapper
 //! let Json(stored_user): Json<User> = con.json_get("user", "$")?;
 //! # Ok(())

--- a/tests/derive_from_redis_value.rs
+++ b/tests/derive_from_redis_value.rs
@@ -27,7 +27,7 @@ pub fn it_should_implement_the_from_redis_value_trait() {
     };
 
     let val = Value::BulkString("{\"id\":1,\"name\":\"Ziggy\",\"addresses\":[{\"Street\":\"Downing\"},{\"Road\":\"Abbey\"}]}".as_bytes().into());
-    let result = User::from_redis_value(&val);
+    let result = User::from_redis_value(val);
     assert_eq!(result, Ok(user));
 }
 
@@ -43,16 +43,16 @@ pub fn it_should_also_deserialize_if_the_input_is_in_brackets() {
     };
 
     let val = Value::BulkString("[{\"id\":1,\"name\":\"Ziggy\",\"addresses\":[{\"Street\":\"Downing\"},{\"Road\":\"Abbey\"}]}]".as_bytes().into());
-    let result = User::from_redis_value(&val);
+    let result = User::from_redis_value(val);
     assert_eq!(result, Ok(user));
 }
 
 #[test]
 pub fn it_should_fail_if_input_is_not_compatible_with_type() {
     let val = Value::BulkString("{}".as_bytes().into());
-    let result = User::from_redis_value(&val);
+    let result = User::from_redis_value(val);
     if let Err(err) = result {
-        assert_eq!(err.to_string(), "Response was of incompatible type - TypeError: Response type not deserializable to User with serde_json. (response was bulk-string('\"{}\"'))".to_string());
+        assert_eq!(err.to_string(), "Incompatible type - Response type not deserializable to User with serde_json. (response was bulk-string('\"{}\"'))".to_string());
     } else {
         panic!("Deserialization should fail.");
     }
@@ -61,9 +61,9 @@ pub fn it_should_fail_if_input_is_not_compatible_with_type() {
 #[test]
 pub fn it_should_fail_if_input_is_not_valid_utf8() {
     let val = Value::BulkString(vec![0, 159, 146, 150]); // Some invalid utf8
-    let result = User::from_redis_value(&val);
+    let result = User::from_redis_value(val);
     if let Err(err) = result {
-        assert_eq!(err.to_string(), "Response was of incompatible type - TypeError: Response was not valid UTF-8 string. (response was binary-data([0, 159, 146, 150]))".to_string());
+        assert_eq!(err.to_string(), "Incompatible type - Response was not valid UTF-8 string. (response was binary-data([0, 159, 146, 150]))".to_string());
     } else {
         panic!("UTF-8 parsing should fail.");
     }
@@ -72,9 +72,13 @@ pub fn it_should_fail_if_input_is_not_valid_utf8() {
 #[test]
 pub fn it_should_fail_if_input_is_missing() {
     let val = Value::Nil;
-    let result = User::from_redis_value(&val);
+    let result = User::from_redis_value(val);
     if let Err(err) = result {
-        assert_eq!(err.to_string(), "Response was of incompatible type - TypeError: Response type was not deserializable to User. (response was nil)".to_string());
+        assert_eq!(
+            err.to_string(),
+            "Incompatible type - Response type was not deserializable to User. (response was nil)"
+                .to_string()
+        );
     } else {
         panic!("UTF-8 parsing should fail.");
     }

--- a/tests/derive_from_redis_value_redis_yaml.rs
+++ b/tests/derive_from_redis_value_redis_yaml.rs
@@ -37,6 +37,6 @@ addresses:
         .as_bytes()
         .into(),
     );
-    let result = User::from_redis_value(&val);
+    let result = User::from_redis_value(val);
     assert_eq!(result, Ok(user));
 }

--- a/tests/derive_with_multiple_generics.rs
+++ b/tests/derive_with_multiple_generics.rs
@@ -19,7 +19,7 @@ pub fn it_should_deserialize_struct_with_multiple_generics() {
     assert_eq!(bytes[0], json);
 
     let val = Value::BulkString(json.into());
-    let result = Pair::<u32, String>::from_redis_value(&val);
+    let result = Pair::<u32, String>::from_redis_value(val);
     assert_eq!(result, Ok(pair));
 }
 
@@ -36,7 +36,7 @@ pub fn it_should_deserialize_json_wrapper_with_multiple_generics() {
         value: "ok".to_string(),
     };
     let val = Value::BulkString("[{\"key\":10,\"value\":\"ok\"}]".as_bytes().into());
-    let result = Json::<PairWithoutTrait<u16, String>>::from_redis_value(&val);
+    let result = Json::<PairWithoutTrait<u16, String>>::from_redis_value(val);
     if let Ok(Json(parsed)) = result {
         assert_eq!(parsed, expected);
     } else {

--- a/tests/json_wrapper.rs
+++ b/tests/json_wrapper.rs
@@ -27,7 +27,7 @@ pub fn it_should_deserialize_json_results() {
     };
 
     let val = Value::BulkString("[{\"id\":1,\"name\":\"Ziggy\",\"addresses\":[{\"Street\":\"Downing\"},{\"Road\":\"Abbey\"}]}]".as_bytes().into());
-    let result = Json::<User>::from_redis_value(&val);
+    let result = Json::<User>::from_redis_value(val);
     if let Ok(Json(parsed_user)) = result {
         assert_eq!(parsed_user, user);
     } else {
@@ -48,7 +48,7 @@ pub fn it_should_also_deserialize_json_wrappable_arguments() {
             .into(),
     );
     // This would fail without the JSON wrapper
-    let result = Json::<Vec<Address>>::from_redis_value(&val);
+    let result = Json::<Vec<Address>>::from_redis_value(val);
     if let Ok(Json(parsed_addresses)) = result {
         assert_eq!(parsed_addresses, addresses);
     } else {
@@ -60,9 +60,9 @@ pub fn it_should_also_deserialize_json_wrappable_arguments() {
 pub fn it_should_fail_if_the_result_is_not_redis_json() {
     // RedisJSON responses should have wrapping brackets (i.e. [{...}])
     let val = Value::BulkString("{\"id\":1,\"name\":\"Ziggy\",\"addresses\":[{\"Street\":\"Downing\"},{\"Road\":\"Abbey\"}]}".as_bytes().into());
-    let result = Json::<User>::from_redis_value(&val);
+    let result = Json::<User>::from_redis_value(val);
     if let Err(err) = result {
-        assert_eq!(err.to_string(), "Response was of incompatible type - TypeError: Response type was not JSON type. (response was bulk-string('\"{\\\"id\\\":1,\\\"name\\\":\\\"Ziggy\\\",\\\"addresses\\\":[{\\\"Street\\\":\\\"Downing\\\"},{\\\"Road\\\":\\\"Abbey\\\"}]}\"'))".to_string());
+        assert_eq!(err.to_string(), "Incompatible type - Response type was not JSON type. (response was bulk-string('\"{\\\"id\\\":1,\\\"name\\\":\\\"Ziggy\\\",\\\"addresses\\\":[{\\\"Street\\\":\\\"Downing\\\"},{\\\"Road\\\":\\\"Abbey\\\"}]}\"'))".to_string());
     } else {
         panic!("RedisJSON unwrapping should fail.");
     }
@@ -71,9 +71,9 @@ pub fn it_should_fail_if_the_result_is_not_redis_json() {
 #[test]
 pub fn it_should_fail_if_input_is_not_compatible_with_type() {
     let val = Value::BulkString("[{}]".as_bytes().into());
-    let result = Json::<User>::from_redis_value(&val);
+    let result = Json::<User>::from_redis_value(val);
     if let Err(err) = result {
-        assert_eq!(err.to_string(), "Response was of incompatible type - TypeError: Response type in JSON was not deserializable. (response was bulk-string('\"[{}]\"'))".to_string());
+        assert_eq!(err.to_string(), "Incompatible type - Response type in JSON was not deserializable. (response was bulk-string('\"[{}]\"'))".to_string());
     } else {
         panic!("Deserialization should fail.");
     }
@@ -82,9 +82,9 @@ pub fn it_should_fail_if_input_is_not_compatible_with_type() {
 #[test]
 pub fn it_should_fail_if_input_is_not_valid_utf8() {
     let val = Value::BulkString(vec![0, 159, 146, 150]); // Some invalid utf8
-    let result = Json::<User>::from_redis_value(&val);
+    let result = Json::<User>::from_redis_value(val);
     if let Err(err) = result {
-        assert_eq!(err.to_string(), "Response was of incompatible type - TypeError: Response was not valid UTF-8 string. (response was binary-data([0, 159, 146, 150]))".to_string());
+        assert_eq!(err.to_string(), "Incompatible type - Response was not valid UTF-8 string. (response was binary-data([0, 159, 146, 150]))".to_string());
     } else {
         panic!("UTF-8 parsing should fail.");
     }
@@ -93,9 +93,13 @@ pub fn it_should_fail_if_input_is_not_valid_utf8() {
 #[test]
 pub fn it_should_fail_if_input_is_missing() {
     let val = Value::Nil;
-    let result = Json::<User>::from_redis_value(&val);
+    let result = Json::<User>::from_redis_value(val);
     if let Err(err) = result {
-        assert_eq!(err.to_string(), "Response was of incompatible type - TypeError: Response type not RedisJSON deserializable. (response was nil)".to_string());
+        assert_eq!(
+            err.to_string(),
+            "Incompatible type - Response type not RedisJSON deserializable. (response was nil)"
+                .to_string()
+        );
     } else {
         panic!("Value Nil should fail.");
     }


### PR DESCRIPTION
- **Breaking change**: Update Redis version to 1.0.0-rc.0
    - This library mostly can be used without any changes, but read the [redis-rs breaking changes](https://github.com/redis-rs/redis-rs/blob/redis-1.0.0-rc.0/version1.md)
    - Implement `ToSingleRedisArg` for types deriving the `ToSingleRedis` macro (see [ToSingleRedisArg trait](https://github.com/redis-rs/redis-rs/blob/redis-1.0.0-rc.0/version1.md#tosingleredisarg-trait-breaking-change))
    - Change `FromRedisValue` to accept owned types (see [More efficient deserialization](https://github.com/redis-rs/redis-rs/blob/redis-1.0.0-rc.0/version1.md#more-efficient-deserialization-breaking-change))
    - Change `FromRedisValue` error from `RedisError` to `ParsingError` ([Better error messages](https://github.com/redis-rs/redis-rs/blob/redis-1.0.0-rc.0/version1.md#better-error-messages-potentially-breaking))
