### PR TITLE
Refactor macros to only use fully qualified names

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Updated
+
+- Refactor macros to only use fully qualified names (except Redis, for compatibility with deadpool-redis, etc)
+
 ## [1.0.0]
 
 ### Updated

--- a/redis-macros-derive/src/lib.rs
+++ b/redis-macros-derive/src/lib.rs
@@ -92,7 +92,7 @@ pub fn from_redis_value_macro(input: TokenStream) -> TokenStream {
         .unwrap_or(quote! {});
 
     let failed_parse_error = quote! {
-        Err(format!("Response type not deserializable to {} with {}. (response was {:?})", #ident_str, #serializer_str, v).into())
+        ::std::result::Result::Err(::std::format!("Response type not deserializable to {} with {}. (response was {:?})", #ident_str, #serializer_str, v).into())
     };
 
     // If the parsing failed, the issue might simply be that the user is using a RedisJSON command
@@ -100,11 +100,11 @@ pub fn from_redis_value_macro(input: TokenStream) -> TokenStream {
     // We can try removing the brackets and try the parse again
     let redis_json_hack = quote! {
         let mut ch = s.chars();
-        if ch.next() == Some('[') && ch.next_back() == Some(']') {
-            if let Ok(s) = #serializer::from_str(ch.as_str()) {
-                Ok(s)
+        if ch.next() == ::std::option::Option::Some('[') && ch.next_back() == ::std::option::Option::Some(']') {
+            if let ::std::result::Result::Ok(s) = #serializer::from_str(ch.as_str()) {
+                ::std::result::Result::Ok(s)
             } else {
-                Err(format!("Response type not RedisJSON deserializable to {}. (response was {:?})", #ident_str, v).into())
+                ::std::result::Result::Err(::std::format!("Response type not RedisJSON deserializable to {}. (response was {:?})", #ident_str, v).into())
             }
         } else {
             #failed_parse_error
@@ -123,17 +123,17 @@ pub fn from_redis_value_macro(input: TokenStream) -> TokenStream {
             fn from_redis_value(v: redis::Value) -> ::std::result::Result<Self, redis::ParsingError> {
                 match v {
                     redis::Value::BulkString(ref bytes) => {
-                        if let Ok(s) = ::std::str::from_utf8(bytes) {
-                            if let Ok(s) = #serializer::from_str(s) {
-                                Ok(s)
+                        if let ::std::result::Result::Ok(s) = ::std::str::from_utf8(bytes) {
+                            if let ::std::result::Result::Ok(s) = #serializer::from_str(s) {
+                                ::std::result::Result::Ok(s)
                             } else {
                                 #failed_parse
                             }
                         } else {
-                            Err(format!("Response was not valid UTF-8 string. (response was {:?})", v).into())
+                            ::std::result::Result::Err(::std::format!("Response was not valid UTF-8 string. (response was {:?})", v).into())
                         }
                     },
-                    _ => Err(format!("Response type was not deserializable to {}. (response was {:?})", #ident_str, v).into()),
+                    _ => ::std::result::Result::Err(::std::format!("Response type was not deserializable to {}. (response was {:?})", #ident_str, v).into()),
                 }
             }
         }

--- a/redis-macros-derive/src/lib.rs
+++ b/redis-macros-derive/src/lib.rs
@@ -76,7 +76,7 @@ pub fn from_redis_value_macro(input: TokenStream) -> TokenStream {
     for param in &generics.params {
         if let GenericParam::Type(type_param) = param {
             let ident = &type_param.ident;
-            let constraint = syn::parse_quote! { #ident : serde::de::DeserializeOwned };
+            let constraint = syn::parse_quote! { #ident : ::serde::de::DeserializeOwned };
 
             if let Some(ref mut w) = where_clause_extended {
                 w.predicates.push(constraint);
@@ -120,10 +120,10 @@ pub fn from_redis_value_macro(input: TokenStream) -> TokenStream {
 
     quote! {
         impl #impl_generics redis::FromRedisValue for #ident #ty_generics #where_with_serialize {
-            fn from_redis_value(v: redis::Value) -> Result<Self, redis::ParsingError> {
+            fn from_redis_value(v: redis::Value) -> ::std::result::Result<Self, redis::ParsingError> {
                 match v {
                     redis::Value::BulkString(ref bytes) => {
-                        if let Ok(s) = std::str::from_utf8(bytes) {
+                        if let Ok(s) = ::std::str::from_utf8(bytes) {
                             if let Ok(s) = #serializer::from_str(s) {
                                 Ok(s)
                             } else {
@@ -199,7 +199,7 @@ pub fn to_redis_args_macro(input: TokenStream) -> TokenStream {
     for param in &generics.params {
         if let GenericParam::Type(type_param) = param {
             let ident = &type_param.ident;
-            let constraint = syn::parse_quote! { #ident : serde::Serialize };
+            let constraint = syn::parse_quote! { #ident : ::serde::Serialize };
 
             if let Some(ref mut w) = where_clause_extended {
                 w.predicates.push(constraint);
@@ -218,7 +218,7 @@ pub fn to_redis_args_macro(input: TokenStream) -> TokenStream {
         impl #impl_generics redis::ToRedisArgs for #ident #ty_generics #where_with_serialize {
             fn write_redis_args<W>(&self, out: &mut W)
             where
-                W: ?Sized + redis::RedisWrite,
+                W: ?::std::marker::Sized + redis::RedisWrite,
             {
                 let buf = #serializer::to_string(&self).unwrap();
                 out.write_arg(&buf.as_bytes())


### PR DESCRIPTION
**Motivation**: macros use Result (and some other things) without using the fully qualified forms (`::std::result::Result`). This could conflict if the user uses another Result type, for example from `eyre`. See #65 for more information.