### PR TITLE
Improve Json::from_redis_value impl

### DIFF
--- a/examples/derive_async.rs
+++ b/examples/derive_async.rs
@@ -1,4 +1,4 @@
-use redis::{Client, AsyncCommands, ErrorKind, RedisError, RedisResult};
+use redis::{AsyncCommands, Client, ErrorKind, RedisError, RedisResult};
 use redis_macros::{FromRedisValue, ToRedisArgs};
 use serde::{Deserialize, Serialize};
 
@@ -25,12 +25,15 @@ struct User {
 async fn main() -> RedisResult<()> {
     // Open new async connection to localhost
     let client = Client::open("redis://localhost:6379")?;
-    let mut con = client.get_multiplexed_async_connection().await.map_err(|_| {
-        RedisError::from((
+    let mut con = client
+        .get_multiplexed_async_connection()
+        .await
+        .map_err(|_| {
+            RedisError::from((
             ErrorKind::InvalidClientConfig,
             "Cannot connect to localhost:6379. Try starting a redis-server process or container.",
         ))
-    })?;
+        })?;
 
     // Define the data you want to store in Redis.
     let user = User {

--- a/examples/derive_generic.rs
+++ b/examples/derive_generic.rs
@@ -21,7 +21,7 @@ fn main() -> RedisResult<()> {
     })?;
 
     // Define the data you want to store in Redis.
-	// Currently only owned types work (String, but not &str)!
+    // Currently only owned types work (String, but not &str)!
     let container = Container {
         inner: "contained".to_string(),
     };

--- a/examples/derive_redisjson.rs
+++ b/examples/derive_redisjson.rs
@@ -1,5 +1,5 @@
-use redis::{Client, JsonAsyncCommands, ErrorKind, RedisError, RedisResult};
-use redis_macros::{FromRedisValue, ToRedisArgs, Json};
+use redis::{Client, ErrorKind, JsonAsyncCommands, RedisError, RedisResult};
+use redis_macros::{FromRedisValue, Json, ToRedisArgs};
 use serde::{Deserialize, Serialize};
 
 /// Define structs to hold the data
@@ -24,12 +24,15 @@ struct User {
 async fn main() -> RedisResult<()> {
     // Open new connection to localhost
     let client = Client::open("redis://localhost:6379")?;
-    let mut con = client.get_multiplexed_async_connection().await.map_err(|_| {
-        RedisError::from((
+    let mut con = client
+        .get_multiplexed_async_connection()
+        .await
+        .map_err(|_| {
+            RedisError::from((
             ErrorKind::InvalidClientConfig,
             "Cannot connect to localhost:6379. Try starting a redis-server process or container.",
         ))
-    })?;
+        })?;
 
     // Define the data you want to store in Redis.
     let user = User {
@@ -54,7 +57,8 @@ async fn main() -> RedisResult<()> {
     // You have to wrap them in Json instead
     let Json(stored_name): Json<String> = con.json_get("user_json", "$.name").await?;
     assert_eq!(user.name, stored_name);
-    let Json(stored_addresses): Json<Vec<Address>> = con.json_get("user_json", "$.addresses").await?;
+    let Json(stored_addresses): Json<Vec<Address>> =
+        con.json_get("user_json", "$.addresses").await?;
     assert_eq!(user.addresses, stored_addresses);
 
     Ok(())

--- a/examples/derive_yaml.rs
+++ b/examples/derive_yaml.rs
@@ -25,12 +25,15 @@ struct User {
 async fn main() -> RedisResult<()> {
     // Open new async connection to localhost
     let client = Client::open("redis://localhost:6379")?;
-    let mut con = client.get_multiplexed_async_connection().await.map_err(|_| {
-        RedisError::from((
+    let mut con = client
+        .get_multiplexed_async_connection()
+        .await
+        .map_err(|_| {
+            RedisError::from((
             ErrorKind::InvalidClientConfig,
             "Cannot connect to localhost:6379. Try starting a redis-server process or container.",
         ))
-    })?;
+        })?;
 
     // Define the data you want to store in Redis.
     let user = User {

--- a/examples/json_wrapper_basic.rs
+++ b/examples/json_wrapper_basic.rs
@@ -22,12 +22,15 @@ struct User {
 async fn main() -> RedisResult<()> {
     // Open new connection to localhost
     let client = Client::open("redis://localhost:6379")?;
-    let mut con = client.get_multiplexed_async_connection().await.map_err(|_| {
-        RedisError::from((
+    let mut con = client
+        .get_multiplexed_async_connection()
+        .await
+        .map_err(|_| {
+            RedisError::from((
             ErrorKind::InvalidClientConfig,
             "Cannot connect to localhost:6379. Try starting a redis-server process or container.",
         ))
-    })?;
+        })?;
 
     // Define the data you want to store in Redis.
     let user = User {
@@ -61,7 +64,6 @@ async fn main() -> RedisResult<()> {
     let _: () = con.json_set("users_wrapped", "$", &users).await?;
     let Json(stored_users): Json<Vec<User>> = con.json_get("users_wrapped", "$").await?;
     assert_eq!(users, stored_users);
-
 
     Ok(())
 }

--- a/examples/json_wrapper_modify.rs
+++ b/examples/json_wrapper_modify.rs
@@ -21,12 +21,15 @@ struct User {
 async fn main() -> RedisResult<()> {
     // Open new connection to localhost
     let client = Client::open("redis://localhost:6379")?;
-    let mut con = client.get_multiplexed_async_connection().await.map_err(|_| {
-        RedisError::from((
+    let mut con = client
+        .get_multiplexed_async_connection()
+        .await
+        .map_err(|_| {
+            RedisError::from((
             ErrorKind::InvalidClientConfig,
             "Cannot connect to localhost:6379. Try starting a redis-server process or container.",
         ))
-    })?;
+        })?;
 
     // Define the data you want to store in Redis.
     let user = User {
@@ -42,24 +45,27 @@ async fn main() -> RedisResult<()> {
     let _: () = con.json_set("user_wrapped_modify", "$", &user).await?;
 
     // Modify inner values with JSON.SET
-    let _: () = con.json_set("user_wrapped_modify", "$.name", &"Bowie")
+    let _: () = con
+        .json_set("user_wrapped_modify", "$.name", &"Bowie")
         .await?;
     let Json(stored_name): Json<String> = con.json_get("user_wrapped_modify", "$.name").await?;
     assert_eq!("Bowie", stored_name);
 
     // Increment numbers with JSON.NUMINCRBY
-    let _: () = con.json_num_incr_by("user_wrapped_modify", "$.id", 1)
+    let _: () = con
+        .json_num_incr_by("user_wrapped_modify", "$.id", 1)
         .await?;
     let Json(stored_id): Json<u32> = con.json_get("user_wrapped_modify", "$.id").await?;
     assert_eq!(2, stored_id);
 
     // Append item to array with JSON.ARR_APPEND
-    let _: () = con.json_arr_append(
-        "user_wrapped_modify",
-        "$.addresses",
-        &Address::Street("Oxford".to_string()),
-    )
-    .await?;
+    let _: () = con
+        .json_arr_append(
+            "user_wrapped_modify",
+            "$.addresses",
+            &Address::Street("Oxford".to_string()),
+        )
+        .await?;
     let Json(stored_addresses): Json<Vec<Address>> =
         con.json_get("user_wrapped_modify", "$.addresses").await?;
     assert_eq!(

--- a/src/json.rs
+++ b/src/json.rs
@@ -57,7 +57,7 @@ where
     T: DeserializeOwned,
 {
     fn from_redis_value(v: Value) -> Result<Json<T>, ParsingError> {
-        let Value::BulkString(ref bytes) = v else {
+        let Value::BulkString(bytes) = &v else {
             return Err(format!("Response type in JSON was not deserializable. (response was {v:?})").into());
         };
 

--- a/src/json.rs
+++ b/src/json.rs
@@ -58,15 +58,25 @@ where
 {
     fn from_redis_value(v: Value) -> Result<Json<T>, ParsingError> {
         let Value::BulkString(bytes) = &v else {
-            return Err(format!("Response type in JSON was not deserializable. (response was {v:?})").into());
+            return Err(format!(
+                "Response type in JSON was not deserializable. (response was {v:?})"
+            )
+            .into());
         };
 
-        let s = ::std::str::from_utf8(bytes).map_err(|e| format!("Response type in JSON is invalid UTF-8: {e}. (response was {v:?})"))?;
+        let s = ::std::str::from_utf8(bytes).map_err(|e| {
+            format!("Response type in JSON is invalid UTF-8: {e}. (response was {v:?})")
+        })?;
         let mut ch = s.chars();
         if !(ch.next() == Some('[') && ch.next_back() == Some(']')) {
-            return Err(format!("Response type in JSON was not deserializable. (response was {v:?})").into());
+            return Err(format!(
+                "Response type in JSON was not deserializable. (response was {v:?})"
+            )
+            .into());
         }
-        let deser = serde_json::from_str(ch.as_str()).map_err(|e| format!("Response type in JSON could not be deserialized: {e} (response was {v:?})"))?;
+        let deser = serde_json::from_str(ch.as_str()).map_err(|e| {
+            format!("Response type in JSON could not be deserialized: {e} (response was {v:?})")
+        })?;
         Ok(Json(deser))
     }
 }

--- a/src/json.rs
+++ b/src/json.rs
@@ -31,7 +31,7 @@ use serde::de::DeserializeOwned;
 /// # use serde::{Deserialize, Serialize};
 /// #[derive(Serialize, Deserialize)]
 /// struct User { id: u32 }
-///  
+///
 /// # fn main () -> redis::RedisResult<()> {
 /// # let client = redis::Client::open("redis://localhost:6379/")?;
 /// # let mut con = client.get_connection()?;
@@ -45,7 +45,7 @@ use serde::de::DeserializeOwned;
 /// This command is designed to use RedisJSON commands. You could probably use this type
 /// to parse normal command outputs, but it removes the first and last character
 /// so it is not recommended.
-///  
+///
 #[derive(Debug)]
 pub struct Json<T>(
     /// The inner type to deserialize
@@ -57,26 +57,16 @@ where
     T: DeserializeOwned,
 {
     fn from_redis_value(v: Value) -> Result<Json<T>, ParsingError> {
-        match v {
-            Value::BulkString(ref bytes) => {
-                if let Ok(s) = ::std::str::from_utf8(bytes) {
-                    let mut ch = s.chars();
-                    if ch.next() == Some('[') && ch.next_back() == Some(']') {
-                        if let Ok(t) = serde_json::from_str(ch.as_str()) {
-                            Ok(Json(t))
-                        } else {
-                            Err(format!("Response type in JSON was not deserializable. (response was {v:?})").into())
-                        }
-                    } else {
-                        Err(format!("Response type was not JSON type. (response was {v:?})").into())
-                    }
-                } else {
-                    Err(format!("Response was not valid UTF-8 string. (response was {v:?})").into())
-                }
-            }
-            _ => Err(
-                format!("Response type not RedisJSON deserializable. (response was {v:?})").into(),
-            ),
+        let Value::BulkString(ref bytes) = v else {
+            return Err(format!("Response type in JSON was not deserializable. (response was {v:?})").into());
+        };
+
+        let s = ::std::str::from_utf8(bytes).map_err(|e| format!("Response type in JSON is invalid UTF-8: {e}. (response was {v:?})"))?;
+        let mut ch = s.chars();
+        if !(ch.next() == Some('[') && ch.next_back() == Some(']')) {
+            return Err(format!("Response type in JSON was not deserializable. (response was {v:?})").into());
         }
+        let deser = serde_json::from_str(ch.as_str()).map_err(|e| format!("Response type in JSON could not be deserialized: {e} (response was {v:?})"))?;
+        Ok(Json(deser))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,13 +182,13 @@ mod json;
 pub use json::Json;
 
 /// Derive macro for the redis crate's [`FromRedisValue`](../redis/trait.FromRedisValue.html) trait to allow parsing Redis responses to this type.
-/// 
+///
 /// For more information see the `redis_macros_derive` crate: [`FromRedisValue`](../redis_macros_derive/derive.FromRedisValue.html)
 #[cfg(feature = "macros")]
 pub use redis_macros_derive::FromRedisValue;
 
 /// Derive macro for the redis crate's [`ToRedisArgs`](../redis/trait.ToRedisArgs.html) trait to allow passing the type to Redis commands.
-/// 
+///
 /// For more information see the `redis_macros_derive` crate: [`ToRedisArgs`](../redis_macros_derive/derive.FromRedisValue.html)
 #[cfg(feature = "macros")]
 pub use redis_macros_derive::ToRedisArgs;

--- a/tests/derive_from_redis_value.rs
+++ b/tests/derive_from_redis_value.rs
@@ -51,35 +51,26 @@ pub fn it_should_also_deserialize_if_the_input_is_in_brackets() {
 pub fn it_should_fail_if_input_is_not_compatible_with_type() {
     let val = Value::BulkString("{}".as_bytes().into());
     let result = User::from_redis_value(val);
-    if let Err(err) = result {
-        assert_eq!(err.to_string(), "Incompatible type - Response type not deserializable to User with serde_json. (response was bulk-string('\"{}\"'))".to_string());
-    } else {
-        panic!("Deserialization should fail.");
-    }
+    let err = result.unwrap_err();
+    assert_eq!(err.to_string(), "Incompatible type - Response type not deserializable to User with serde_json. (response was bulk-string('\"{}\"'))".to_string());
 }
 
 #[test]
 pub fn it_should_fail_if_input_is_not_valid_utf8() {
     let val = Value::BulkString(vec![0, 159, 146, 150]); // Some invalid utf8
     let result = User::from_redis_value(val);
-    if let Err(err) = result {
-        assert_eq!(err.to_string(), "Incompatible type - Response was not valid UTF-8 string. (response was binary-data([0, 159, 146, 150]))".to_string());
-    } else {
-        panic!("UTF-8 parsing should fail.");
-    }
+    let err = result.unwrap_err();
+    assert_eq!(err.to_string(), "Incompatible type - Response was not valid UTF-8 string. (response was binary-data([0, 159, 146, 150]))".to_string());
 }
 
 #[test]
 pub fn it_should_fail_if_input_is_missing() {
     let val = Value::Nil;
     let result = User::from_redis_value(val);
-    if let Err(err) = result {
-        assert_eq!(
-            err.to_string(),
-            "Incompatible type - Response type was not deserializable to User. (response was nil)"
-                .to_string()
-        );
-    } else {
-        panic!("UTF-8 parsing should fail.");
-    }
+    let err = result.unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Incompatible type - Response type was not deserializable to User. (response was nil)"
+            .to_string()
+    );
 }

--- a/tests/derive_to_redis_args_redis_yaml.rs
+++ b/tests/derive_to_redis_args_redis_yaml.rs
@@ -37,6 +37,6 @@ addresses:
 - !Street Downing
 - !Road Abbey
 "
-            .as_bytes()
+        .as_bytes()
     );
 }


### PR DESCRIPTION
I had some errors while migrating to redis-rs 1.0.0 and found this implementation for `Json::from_redis_value`. I felt this could be improved somewhat. The indentation makes the function harder to follow, and error messages from `std::from_str` and `serde_json::from_str` are discarded.

I improved the error messages here, and removed the indentation, making it much clearer what call throws what error. I also took the liberty of running `cargo fmt`